### PR TITLE
Implement basic JUCE plugin skeleton

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1,1 +1,22 @@
-// Editor cpp content here
+#include "PluginEditor.h"
+
+BrainwaveVSTAudioProcessorEditor::BrainwaveVSTAudioProcessorEditor (BrainwaveVSTAudioProcessor& p)
+    : AudioProcessorEditor (&p), audioProcessor (p)
+{
+    setSize (400, 300);
+}
+
+BrainwaveVSTAudioProcessorEditor::~BrainwaveVSTAudioProcessorEditor() = default;
+
+void BrainwaveVSTAudioProcessorEditor::paint (juce::Graphics& g)
+{
+    g.fillAll (juce::Colours::black);
+    g.setColour (juce::Colours::white);
+    g.setFont (15.0f);
+    g.drawFittedText ("BrainwaveVST", getLocalBounds(), juce::Justification::centred, 1);
+}
+
+void BrainwaveVSTAudioProcessorEditor::resized()
+{
+}
+

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -1,1 +1,20 @@
-// Editor header content here
+#pragma once
+
+#include <JuceHeader.h>
+#include "PluginProcessor.h"
+
+class BrainwaveVSTAudioProcessorEditor : public juce::AudioProcessorEditor
+{
+public:
+    explicit BrainwaveVSTAudioProcessorEditor (BrainwaveVSTAudioProcessor&);
+    ~BrainwaveVSTAudioProcessorEditor() override;
+
+    void paint (juce::Graphics&) override;
+    void resized() override;
+
+private:
+    BrainwaveVSTAudioProcessor& audioProcessor;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BrainwaveVSTAudioProcessorEditor)
+};
+

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1,1 +1,127 @@
-// Processor cpp content here
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+BrainwaveVSTAudioProcessor::BrainwaveVSTAudioProcessor()
+#ifndef JucePlugin_PreferredChannelConfigurations
+    : AudioProcessor (BusesProperties()
+#if ! JucePlugin_IsMidiEffect
+#if ! JucePlugin_IsSynth
+                       .withInput ("Input", juce::AudioChannelSet::stereo(), true)
+#endif
+                       .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
+#endif
+                       )
+#endif
+{
+}
+
+BrainwaveVSTAudioProcessor::~BrainwaveVSTAudioProcessor() = default;
+
+const juce::String BrainwaveVSTAudioProcessor::getName() const
+{
+    return JucePlugin_Name;
+}
+
+bool BrainwaveVSTAudioProcessor::acceptsMidi() const
+{
+    return JucePlugin_WantsMidiInput;
+}
+
+bool BrainwaveVSTAudioProcessor::producesMidi() const
+{
+    return JucePlugin_ProducesMidiOutput;
+}
+
+bool BrainwaveVSTAudioProcessor::isMidiEffect() const
+{
+    return JucePlugin_IsMidiEffect;
+}
+
+double BrainwaveVSTAudioProcessor::getTailLengthSeconds() const
+{
+    return 0.0;
+}
+
+int BrainwaveVSTAudioProcessor::getNumPrograms()
+{
+    return 1;
+}
+
+int BrainwaveVSTAudioProcessor::getCurrentProgram()
+{
+    return 0;
+}
+
+void BrainwaveVSTAudioProcessor::setCurrentProgram (int)
+{
+}
+
+const juce::String BrainwaveVSTAudioProcessor::getProgramName (int)
+{
+    return {};
+}
+
+void BrainwaveVSTAudioProcessor::changeProgramName (int, const juce::String&)
+{
+}
+
+void BrainwaveVSTAudioProcessor::prepareToPlay (double, int)
+{
+}
+
+void BrainwaveVSTAudioProcessor::releaseResources()
+{
+}
+
+#ifndef JucePlugin_PreferredChannelConfigurations
+bool BrainwaveVSTAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+{
+#if JucePlugin_IsMidiEffect
+    juce::ignoreUnused (layouts);
+    return true;
+#else
+    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono()
+        && layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+        return false;
+
+    if (! JucePlugin_IsSynth && layouts.getMainInputChannelSet() != layouts.getMainOutputChannelSet())
+        return false;
+
+    return true;
+#endif
+}
+#endif
+
+void BrainwaveVSTAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer&)
+{
+    juce::ScopedNoDenormals noDenormals;
+    auto totalNumInputChannels  = getTotalNumInputChannels();
+    auto totalNumOutputChannels = getTotalNumOutputChannels();
+
+    for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
+        buffer.clear (i, 0, buffer.getNumSamples());
+}
+
+bool BrainwaveVSTAudioProcessor::hasEditor() const
+{
+    return true;
+}
+
+juce::AudioProcessorEditor* BrainwaveVSTAudioProcessor::createEditor()
+{
+    return new BrainwaveVSTAudioProcessorEditor (*this);
+}
+
+void BrainwaveVSTAudioProcessor::getStateInformation (juce::MemoryBlock&)
+{
+}
+
+void BrainwaveVSTAudioProcessor::setStateInformation (const void*, int)
+{
+}
+
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+{
+    return new BrainwaveVSTAudioProcessor();
+}
+

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -1,1 +1,40 @@
-// Processor header content here
+#pragma once
+
+#include <JuceHeader.h>
+
+class BrainwaveVSTAudioProcessor : public juce::AudioProcessor
+{
+public:
+    BrainwaveVSTAudioProcessor();
+    ~BrainwaveVSTAudioProcessor() override;
+
+    void prepareToPlay (double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+    bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
+
+    void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override;
+
+    const juce::String getName() const override;
+
+    bool acceptsMidi() const override;
+    bool producesMidi() const override;
+    bool isMidiEffect() const override;
+    double getTailLengthSeconds() const override;
+
+    int getNumPrograms() override;
+    int getCurrentProgram() override;
+    void setCurrentProgram (int index) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
+
+    void getStateInformation (juce::MemoryBlock& destData) override;
+    void setStateInformation (const void* data, int sizeInBytes) override;
+
+private:
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BrainwaveVSTAudioProcessor)
+};
+


### PR DESCRIPTION
## Summary
- replace placeholder files with functional JUCE plugin skeleton

## Testing
- `cmake -S . -B build` *(fails: add_subdirectory given source "../JUCE" which is not an existing directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d0d91bc64832bb8dedc5b1d15f7f6